### PR TITLE
Resource: add is user resource author helper method

### DIFF
--- a/src/EasyBib/Api/Client/ApiTraverser.php
+++ b/src/EasyBib/Api/Client/ApiTraverser.php
@@ -4,6 +4,7 @@ namespace EasyBib\Api\Client;
 
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\CacheProvider;
+use EasyBib\Api\Client\Resource\Collection;
 use EasyBib\Api\Client\Resource\Resource;
 use EasyBib\Api\Client\Resource\ResourceFactory;
 use EasyBib\Api\Client\Validation\ResponseValidator;

--- a/src/EasyBib/Api/Client/Resource/RelationsContainer.php
+++ b/src/EasyBib/Api/Client/Resource/RelationsContainer.php
@@ -48,7 +48,7 @@ class RelationsContainer
 
     /**
      * @param string $rel
-     * @return Resource
+     * @return Relation
      */
     public function get($rel)
     {

--- a/src/EasyBib/Api/Client/Resource/Resource.php
+++ b/src/EasyBib/Api/Client/Resource/Resource.php
@@ -145,6 +145,19 @@ class Resource
     }
 
     /**
+     * @return bool
+     */
+    public function isCurrentUserAuthor()
+    {
+        $relation = $this->relationsContainer->get('author');
+        if (!$relation) {
+            return false;
+        }
+
+        return $relation->getHref() === $this->apiTraverser->getUserBaseUrl();
+    }
+
+    /**
      * @param string $method
      * @param string $rel
      * @param array $data

--- a/tests/EasyBib/Tests/Api/Client/Resource/ResourceTest.php
+++ b/tests/EasyBib/Tests/Api/Client/Resource/ResourceTest.php
@@ -260,6 +260,28 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['data' => ['foo' => 'bar']], $resource->toArray());
     }
 
+    public function testIsCurrentUserAuthor()
+    {
+        $resource = $this->getResource((object) ['data' => (object) ['foo' => 'bar']]);
+        $this->assertFalse($resource->isCurrentUserAuthor());
+    }
+
+    public function testIsCurrentUserAuthorNoAuthorRelation()
+    {
+        $resource = $this->getResource((object) [
+            'data' => (object) ['foo' => 'bar'],
+            'links' => [
+                (object) [
+                    'href' => '/user/',
+                    'rel' => 'author',
+                    'type' => 'application/vnd.com.easybib.data+json',
+                    'title' => 'user@example.com',
+                ]
+            ]
+        ]);
+        $this->assertTrue($resource->isCurrentUserAuthor());
+    }
+
     /**
      * @param \stdClass $data
      * @return Resource


### PR DESCRIPTION
Adds helper method to check current user is resource author.

Problem is that once you have the resource there is no way to check this unless you pass the ApiTraverser everywhere.