### PR TITLE
Travis: enable php7 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,22 @@ before_script:
   - ./composer.phar install --dev --prefer-source --no-interaction
 
 php:
-  - 5.5
+  - 5.6
+  - 7.0
+
+matrix:
+  allow_failures:
+  - php: 7
+  fast_finish: true
 
 script:
   - ./bin/phpci
+
+cache:
+  directories:
+  - $HOME/.composer/cache/repo/
+  - $TRAVIS_BUILD_DIR/vendor/
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
I need to add async curl support and will at the same time make sure this fully works with php7.

Edit: Just saw that resource is only soft reserved (http://php.net/manual/en/reserved.other-reserved-words.php).