### PR TITLE
Resource is a soft reserved php keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,16 +82,16 @@ $api = $apiBuilder->createWithAuthorizationCodeGrant([
     'redirect_url' => 'http://myapp.example.com/handle-token-response',
 ]);
 
-$user = $api->getUser();  // user serves as the entry point for traversing resources
+$user = $api->getUser();  // user serves as the entry point for traversing api resources
 ```
 
-### Retrieving resources
+### Retrieving api resources
 
 Once you have an API object, you can use it to traverse the API.
 The two entry points are `$api->getUser()` and `$api->getProjects()`.
 
-`getUser()` will return a `Resource` representing the user; calling
-`getResourceData()->getRelations()` on the user resource will return a set
+`getUser()` will return a `ApiResource` representing the user; calling
+`getResourceData()->getRelations()` on the user api resource will return a set
 of available references which can be called from the user. So the call chain
 for a particular project's citations might be
 
@@ -135,7 +135,7 @@ a guest user registers or logs in, and needs a new token which will be
 associated with the permanent user account. In this case, the application
 consuming the API **must** instantiate a new `ApiTraverser` or call `setCache()`,
 with a new cache or cache namespace, to ensure that the `ApiTraverser` will
-not return resources cached during the original session.
+not return api resources cached during the original session.
 
 By default, `ApiTraverser` uses a PHP-array-based cache, so unless you have
 implemented a different caching backend, you can simply instantiate a new

--- a/src/EasyBib/Api/Client/ApiResource/ApiResource.php
+++ b/src/EasyBib/Api/Client/ApiResource/ApiResource.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace EasyBib\Api\Client\Resource;
+namespace EasyBib\Api\Client\ApiResource;
 
 use EasyBib\Api\Client\ApiTraverser;
 use EasyBib\Api\Client\Validation\ResourceNotFoundException;
 
-class Resource
+class ApiResource
 {
     /**
      * @var \stdClass

--- a/src/EasyBib/Api/Client/ApiResource/Collection.php
+++ b/src/EasyBib/Api/Client/ApiResource/Collection.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace EasyBib\Api\Client\Resource;
+namespace EasyBib\Api\Client\ApiResource;
 
 use EasyBib\Api\Client\ApiTraverser;
 
 /**
  * @SuppressWarnings(PHPMD.TooManyMethods)
  */
-class Collection extends Resource implements \ArrayAccess, \Iterator
+class Collection extends ApiResource implements \ArrayAccess, \Iterator
 {
     /**
      * @var \ArrayIterator

--- a/src/EasyBib/Api/Client/ApiResource/InvalidResourceLinkException.php
+++ b/src/EasyBib/Api/Client/ApiResource/InvalidResourceLinkException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyBib\Api\Client\Resource;
+namespace EasyBib\Api\Client\ApiResource;
 
 class InvalidResourceLinkException extends \UnexpectedValueException
 {

--- a/src/EasyBib/Api/Client/ApiResource/Relation.php
+++ b/src/EasyBib/Api/Client/ApiResource/Relation.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyBib\Api\Client\Resource;
+namespace EasyBib\Api\Client\ApiResource;
 
 use EasyBib\Api\Client\LinkTransformer\LinkTransformerInterface;
 use EasyBib\Api\Client\LinkTransformer\NullLinkTransformer;

--- a/src/EasyBib/Api/Client/ApiResource/RelationsContainer.php
+++ b/src/EasyBib/Api/Client/ApiResource/RelationsContainer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyBib\Api\Client\Resource;
+namespace EasyBib\Api\Client\ApiResource;
 
 class RelationsContainer
 {

--- a/src/EasyBib/Api/Client/ApiResource/ResourceErrorException.php
+++ b/src/EasyBib/Api/Client/ApiResource/ResourceErrorException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyBib\Api\Client\Resource;
+namespace EasyBib\Api\Client\ApiResource;
 
 class ResourceErrorException extends \Exception
 {

--- a/src/EasyBib/Api/Client/ApiResource/ResourceFactory.php
+++ b/src/EasyBib/Api/Client/ApiResource/ResourceFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyBib\Api\Client\Resource;
+namespace EasyBib\Api\Client\ApiResource;
 
 use EasyBib\Api\Client\ApiTraverser;
 use Guzzle\Http\Message\Response;
@@ -30,7 +30,7 @@ class ResourceFactory
             return new Collection($data, $this->apiTraverser);
         }
 
-        return new Resource($data, $this->apiTraverser);
+        return new ApiResource($data, $this->apiTraverser);
     }
 
     /**

--- a/src/EasyBib/Api/Client/ApiTraverser.php
+++ b/src/EasyBib/Api/Client/ApiTraverser.php
@@ -4,9 +4,9 @@ namespace EasyBib\Api\Client;
 
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\CacheProvider;
-use EasyBib\Api\Client\Resource\Collection;
-use EasyBib\Api\Client\Resource\Resource;
-use EasyBib\Api\Client\Resource\ResourceFactory;
+use EasyBib\Api\Client\ApiResource\Collection;
+use EasyBib\Api\Client\ApiResource\ApiResource;
+use EasyBib\Api\Client\ApiResource\ResourceFactory;
 use EasyBib\Api\Client\Validation\ResponseValidator;
 use EasyBib\Guzzle\Plugin\RequestHeader;
 use Guzzle\Http\ClientInterface;

--- a/tests/EasyBib/Tests/Api/Client/ApiBuilderTest.php
+++ b/tests/EasyBib/Tests/Api/Client/ApiBuilderTest.php
@@ -3,7 +3,7 @@
 namespace EasyBib\Tests\Api\Client;
 
 use EasyBib\Api\Client\ApiBuilder;
-use EasyBib\Api\Client\Resource\Resource;
+use EasyBib\Api\Client\ApiResource\ApiResource;
 use EasyBib\OAuth2\Client\TokenStore;
 use EasyBib\Tests\Mocks\OAuth2\Client\ExceptionMockRedirector;
 use EasyBib\Tests\Mocks\OAuth2\Client\MockRedirectException;
@@ -123,7 +123,7 @@ class ApiBuilderTest extends \PHPUnit_Framework_TestCase
             ['data' => ['foo' => 'bar']]
         );
 
-        $this->assertInstanceOf(Resource::class, $api->getUser());
+        $this->assertInstanceOf(ApiResource::class, $api->getUser());
     }
 
     private function prepareTokenResponse()

--- a/tests/EasyBib/Tests/Api/Client/ApiMockResponses.php
+++ b/tests/EasyBib/Tests/Api/Client/ApiMockResponses.php
@@ -2,7 +2,6 @@
 
 namespace EasyBib\Tests\Api\Client;
 
-use EasyBib\Api\Client\Resource\Resource;
 use EasyBib\OAuth2\Client\AuthorizationCodeGrant;
 use EasyBib\OAuth2\Client\AuthorizationCodeGrant\AuthorizationCodeSession;
 use EasyBib\OAuth2\Client\JsonWebTokenGrant;

--- a/tests/EasyBib/Tests/Api/Client/ApiResource/ApiResourceTest.php
+++ b/tests/EasyBib/Tests/Api/Client/ApiResource/ApiResourceTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace EasyBib\Tests\Api\Client\Resource;
+namespace EasyBib\Tests\Api\Client\ApiResource;
 
 use EasyBib\Api\Client\ApiTraverser;
-use EasyBib\Api\Client\Resource\Resource;
-use EasyBib\Api\Client\Resource\ResourceFactory;
+use EasyBib\Api\Client\ApiResource\ApiResource;
+use EasyBib\Api\Client\ApiResource\ResourceFactory;
 use EasyBib\Api\Client\Validation\ResourceNotFoundException;
 use EasyBib\Tests\Api\Client\ApiMockResponses;
 use Guzzle\Http\Client;
@@ -12,7 +12,7 @@ use Guzzle\Http\Message\Response;
 use Guzzle\Plugin\History\HistoryPlugin;
 use Guzzle\Plugin\Mock\MockPlugin;
 
-class ResourceTest extends \PHPUnit_Framework_TestCase
+class ApiResourceTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var ApiMockResponses
@@ -66,7 +66,7 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
 
         $goodLinkedResource = $firstResource->get('foo rel');
 
-        $this->assertInstanceOf(Resource::class, $goodLinkedResource);
+        $this->assertInstanceOf(ApiResource::class, $goodLinkedResource);
         $this->assertEquals('bar', $goodLinkedResource->getData()->foo);
     }
 
@@ -100,7 +100,7 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
 
         $goodLinkedResource = $firstResource->post('foo rel', $nextResource);
 
-        $this->assertInstanceOf(Resource::class, $goodLinkedResource);
+        $this->assertInstanceOf(ApiResource::class, $goodLinkedResource);
         $this->assertEquals('bar', $goodLinkedResource->getData()->foo);
     }
 
@@ -134,7 +134,7 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
 
         $goodLinkedResource = $firstResource->put('foo rel', $nextResource);
 
-        $this->assertInstanceOf(Resource::class, $goodLinkedResource);
+        $this->assertInstanceOf(ApiResource::class, $goodLinkedResource);
         $this->assertEquals('bar', $goodLinkedResource->getData()->foo);
     }
 
@@ -250,7 +250,7 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
     public function testSetLocationWhereInvalid()
     {
         $this->setExpectedException(\InvalidArgumentException::class);
-        $resource = new Resource(new \stdClass(), $this->api);
+        $resource = new ApiResource(new \stdClass(), $this->api);
         $resource->setLocation([]);
     }
 

--- a/tests/EasyBib/Tests/Api/Client/ApiResource/CollectionTest.php
+++ b/tests/EasyBib/Tests/Api/Client/ApiResource/CollectionTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace EasyBib\Tests\Api\Client\Resource;
+namespace EasyBib\Tests\Api\Client\ApiResource;
 
 use EasyBib\Api\Client\ApiTraverser;
-use EasyBib\Api\Client\Resource\Collection;
-use EasyBib\Api\Client\Resource\Resource;
-use EasyBib\Api\Client\Resource\ResourceFactory;
+use EasyBib\Api\Client\ApiResource\Collection;
+use EasyBib\Api\Client\ApiResource\ApiResource;
+use EasyBib\Api\Client\ApiResource\ResourceFactory;
 use Guzzle\Http\Client;
 use Guzzle\Http\Message\Response;
 
@@ -51,7 +51,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     public function testOffsetGet(array $data)
     {
         $collection = $this->getCollection($data);
-        $this->assertInstanceOf(Resource::class, $collection[0]);
+        $this->assertInstanceOf(ApiResource::class, $collection[0]);
     }
 
     /**

--- a/tests/EasyBib/Tests/Api/Client/ApiResource/RelationTest.php
+++ b/tests/EasyBib/Tests/Api/Client/ApiResource/RelationTest.php
@@ -2,7 +2,7 @@
 
 namespace EasyBib\Tests\Api\Client\Resource;
 
-use EasyBib\Api\Client\Resource\Relation;
+use EasyBib\Api\Client\ApiResource\Relation;
 use EasyBib\Tests\Mocks\Api\Client\LinkTransformer\MockLinkTransformer;
 
 /**
@@ -135,7 +135,7 @@ class RelationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \EasyBib\Api\Client\Resource\InvalidResourceLinkException
+     * @expectedException \EasyBib\Api\Client\ApiResource\InvalidResourceLinkException
      * @param string $data
      * @dataProvider dataProviderInvalid
      */

--- a/tests/EasyBib/Tests/Api/Client/ApiResource/RelationsContainerTest.php
+++ b/tests/EasyBib/Tests/Api/Client/ApiResource/RelationsContainerTest.php
@@ -2,8 +2,8 @@
 
 namespace EasyBib\Tests\Api\Client\Resource;
 
-use EasyBib\Api\Client\Resource\Relation;
-use EasyBib\Api\Client\Resource\RelationsContainer;
+use EasyBib\Api\Client\ApiResource\Relation;
+use EasyBib\Api\Client\ApiResource\RelationsContainer;
 
 class RelationsContainerTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/EasyBib/Tests/Api/Client/ApiResource/ResourceFactoryTest.php
+++ b/tests/EasyBib/Tests/Api/Client/ApiResource/ResourceFactoryTest.php
@@ -3,9 +3,9 @@
 namespace EasyBib\Tests\Api\Client\Resource;
 
 use EasyBib\Api\Client\ApiTraverser;
-use EasyBib\Api\Client\Resource\Collection;
-use EasyBib\Api\Client\Resource\ResourceErrorException;
-use EasyBib\Api\Client\Resource\ResourceFactory;
+use EasyBib\Api\Client\ApiResource\Collection;
+use EasyBib\Api\Client\ApiResource\ResourceErrorException;
+use EasyBib\Api\Client\ApiResource\ResourceFactory;
 use Guzzle\Http\Client;
 
 class ResourceFactoryTest extends \PHPUnit_Framework_TestCase

--- a/tests/EasyBib/Tests/Api/Client/ApiTraverserTest.php
+++ b/tests/EasyBib/Tests/Api/Client/ApiTraverserTest.php
@@ -5,9 +5,9 @@ namespace EasyBib\Tests\Api\Client;
 use Doctrine\Common\Cache\ArrayCache;
 use EasyBib\Api\Client\ApiTraverser;
 use EasyBib\Api\Client\CacheKey;
-use EasyBib\Api\Client\Resource\Collection;
-use EasyBib\Api\Client\Resource\Relation;
-use EasyBib\Api\Client\Resource\Resource;
+use EasyBib\Api\Client\ApiResource\Collection;
+use EasyBib\Api\Client\ApiResource\Relation;
+use EasyBib\Api\Client\ApiResource\ApiResource;
 use EasyBib\Api\Client\Validation\ApiErrorException;
 use EasyBib\Api\Client\Validation\ExpiredTokenException;
 use EasyBib\Api\Client\Validation\InfrastructureErrorException;
@@ -574,7 +574,7 @@ class ApiTraverserTest extends \PHPUnit_Framework_TestCase
 
         $this->api->get($url, $arguments);
         $this->assertTrue($cache->contains($key));
-        $this->assertInstanceOf(Resource::class, $cache->fetch($key));
+        $this->assertInstanceOf(ApiResource::class, $cache->fetch($key));
     }
 
     /**
@@ -627,11 +627,11 @@ class ApiTraverserTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param array $expectedResponseArray
-     * @param Resource $resource
+     * @param ApiResource $resource
      */
     private function shouldHaveReturnedAResource(
         array $expectedResponseArray,
-        Resource $resource
+        ApiResource $resource
     ) {
         $this->assertSameData($expectedResponseArray, $resource);
 
@@ -643,11 +643,11 @@ class ApiTraverserTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param array $expectedResponseArray
-     * @param Resource $resource
+     * @param ApiResource $resource
      */
     private function shouldHaveReturnedADeletedResource(
         array $expectedResponseArray,
-        Resource $resource
+        ApiResource $resource
     ) {
         $this->assertSameData($expectedResponseArray, $resource);
     }
@@ -665,9 +665,9 @@ class ApiTraverserTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param array $expectedResponseArray
-     * @param Resource $resource
+     * @param ApiResource $resource
      */
-    private function assertSameData(array $expectedResponseArray, Resource $resource)
+    private function assertSameData(array $expectedResponseArray, ApiResource $resource)
     {
         $this->assertEquals(
             $this->recursiveCastObject($expectedResponseArray['data']),


### PR DESCRIPTION
```resource``` is a soft reserved keyword and should not be used (see: http://php.net/manual/en/reserved.other-reserved-words.php)

Needs to be released as new major release!